### PR TITLE
Add jsonschema validation for task options

### DIFF
--- a/koji-containerbuild.spec
+++ b/koji-containerbuild.spec
@@ -68,6 +68,13 @@ Requires:   koji-containerbuild
 Requires:   osbs-client
 Requires:   python-urlgrabber
 Requires:   python-dockerfile-parse
+%if 0%{with python3}
+Requires:   python3-setuptools
+Requires:   python3-jsonschema
+%else
+Requires:   python2-setuptools
+Requires:   python2-jsonschema
+%endif
 
 %description builder
 Builder plugin that extend Koji to communicate with OpenShift build system and

--- a/koji_containerbuild/plugins/hub_containerbuild.py
+++ b/koji_containerbuild/plugins/hub_containerbuild.py
@@ -48,8 +48,9 @@ def buildContainer(src, target, opts=None, priority=None, channel='container'):
 
     Returns the task ID
     """
-    if not opts:
+    if opts is None:
         opts = {}
+
     taskOpts = {}
     if priority:
         if priority < 0:

--- a/koji_containerbuild/schemas/build_params.json
+++ b/koji_containerbuild/schemas/build_params.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Parameters for a koji containerBuild task.",
+
+  "type": "array",
+  "items": [
+    {
+      "type": "string",
+      "description": "Source URI."
+    },
+    {
+      "type": "string",
+      "description": "Build target."
+    },
+    {
+      "type": ["object", "null"],
+      "properties": {
+        "scratch": {
+          "type": "boolean",
+          "description": "Perform a scratch build?"
+        },
+        "isolated": {
+          "type": "boolean",
+          "description": "Perform an isolated build?"
+        },
+        "yum_repourls": {
+          "type": ["array", "null"],
+          "items": {
+            "type": "string"
+          },
+          "description": "URLs of yum repo files."
+        },
+        "git_branch": {
+          "type": ["string", "null"],
+          "description": "Git branch to build from."
+        },
+        "push_url": {
+          "type": ["string", "null"]
+        },
+        "koji_parent_build": {
+          "type": ["string", "null"],
+          "description": "Overwrite parent image with image from koji build."
+        },
+        "release": {
+          "type": ["string", "null"],
+          "description": "Set release value."
+        },
+        "flatpak": {
+          "type": "boolean",
+          "description": "Build a flatpak instead of a container?"
+        },
+        "compose_ids": {
+          "type": ["array", "null"],
+          "items": {
+            "type": "integer"
+          },
+          "description": "ODCS composes used."
+        },
+        "signing_intent": {
+          "type": ["string", "null"],
+          "description": "Signing intent of the ODCS composes."
+        }
+      }
+    }
+  ]
+}

--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,8 @@ setup(
     ],
     cmdclass={
         'sdist': TitoDist,
+    },
+    package_data={
+        'koji_containerbuild': ['schemas/*.json']
     }
 )

--- a/test.sh
+++ b/test.sh
@@ -19,14 +19,15 @@ if [[ $OS == "fedora" ]]; then
   PIP="pip$PYTHON_VERSION"
   PKG="dnf"
   PKG_EXTRA="dnf-plugins-core git-core
-             python$PYTHON_VERSION-koji python$PYTHON_VERSION-koji-hub"
+             python$PYTHON_VERSION-koji python$PYTHON_VERSION-koji-hub
+             python$PYTHON_VERSION-jsonschema"
   BUILDDEP="dnf builddep"
   PYTHON="python$PYTHON_VERSION"
 else
   PIP_PKG="python-pip"
   PIP="pip"
   PKG="yum"
-  PKG_EXTRA="yum-utils git-core koji koji-hub"
+  PKG_EXTRA="yum-utils git-core koji koji-hub python2-jsonschema"
   BUILDDEP="yum-builddep"
   PYTHON="python"
 fi

--- a/tests/test_hub_containerbuild.py
+++ b/tests/test_hub_containerbuild.py
@@ -23,31 +23,73 @@ from flexmock import flexmock
 from koji_containerbuild.plugins import hub_containerbuild
 
 
-@pytest.mark.parametrize('admin_perms', [True, False])
-@pytest.mark.parametrize('priority', [1, 0, None, -1])
-def test_priority_permissions(priority, admin_perms):
-    src, target = 'source', 'target'
+def mocked_koji_context(admin_perms=False):
+    """
+    Mock koji context for testing hub_containerbuild (replace
+    hub_containerbuild.context with the result of this function).
 
-    task_opts = {}
-    if priority:
-        task_opts['priority'] = koji.PRIO_DEFAULT + priority
-
+    :param admin_perms: Does the user have admin permissions?
+    :return: A mock object to replace hub_containerbuild.context with.
+    """
     session = flexmock()
     (session
         .should_receive('hasPerm')
         .with_args('admin')
         .and_return(admin_perms))
-    hub_containerbuild.context = flexmock(session=session)
 
-    should_succeed = priority is None or priority >= 0 or admin_perms
+    context = flexmock(session=session)
+    return context
+
+
+def mocked_kojihub_for_task(src, target, opts,
+                            priority=None, channel='container',
+                            should_receive_task=True):
+    """
+    Mock koji-hub for testing hub_containerbuild (replace
+    hub_containerbuild.kojihub with the result of this function).
+
+    :param src: 1st argument for a 'buildContainer' task
+    :param target: 2nd argument for a 'buildContainer' task
+    :param opts: 3rd argument for a 'buildContainer' task
+    :param priority: keyword argument for `make_task`,
+                     is expected only if not None, not 0
+    :param channel: keyword argument for `make_task`,
+                    is expected only if not None, not empty
+    :param should_receive_task: Should kojihub receive the call to `make_task`?
+
+    :return: A mock object to replace hub_containerbuild.kojihub with.
+    """
+    task_opts = {}
+    if channel:
+        task_opts['channel'] = channel
+    if priority:
+        task_opts['priority'] = koji.PRIO_DEFAULT + priority
 
     kojihub = flexmock()
     (kojihub
         .should_receive('make_task')
-        .with_args('buildContainer', [src, target, {}],
-                   channel='container', **task_opts)
-        .times(1 if should_succeed else 0))
-    hub_containerbuild.kojihub = kojihub
+        .with_args('buildContainer',
+                   [src, target, opts],
+                   **task_opts)
+        .times(1 if should_receive_task else 0))
+
+    return kojihub
+
+
+@pytest.mark.parametrize('admin_perms', [True, False])
+@pytest.mark.parametrize('priority', [1, 0, None, -1])
+def test_priority_permissions(priority, admin_perms, monkeypatch):
+    src, target = 'source', 'target'
+
+    context = mocked_koji_context(admin_perms)
+    monkeypatch.setattr(hub_containerbuild, 'context', context)
+
+    should_succeed = priority is None or priority >= 0 or admin_perms
+
+    kojihub = mocked_kojihub_for_task(src, target, {},
+                                      priority=priority,
+                                      should_receive_task=should_succeed)
+    monkeypatch.setattr(hub_containerbuild, 'kojihub', kojihub)
 
     if should_succeed:
         hub_containerbuild.buildContainer(src, target, priority=priority)


### PR DESCRIPTION
* OSBS-7672

The schema is used to validate arguments for the BuildContainerTask
handler() method, it validates the types of the individual arguments
(src: string, target: string, opts: dict or none) as well as the types
of parameters in the 'opts' dictionary. The schema for the 'opts' dict
is not complete, it allows unknown parameters because some options are
missing. This can be amended in the future.