### PR TITLE
README: correct path to Koji Hub configuration file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,7 +91,7 @@ Koji hub
 If you already use any Koji hub plugin you need to use same path for this
 plugin too. Default path used by Koji hub is `/usr/lib/koji-hub-plugins`.
 
-Modify `/etc/koji-hub.conf`:
+Modify `/etc/koji-hub/hub.conf`:
 
 * set `PluginPath` to a directory which contains `hub_containerbuild.py` from this
   package.


### PR DESCRIPTION
The Koji Hub configuration file is in a sub-directory, not in the top-level `/etc` directory.  

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Pull request includes link to an osbs-docs PR for user documentation updates