### PR TITLE
pass triggered_afer_koji_task to osbs-client even when it is 0

### DIFF
--- a/koji_containerbuild/plugins/builder_containerbuild.py
+++ b/koji_containerbuild/plugins/builder_containerbuild.py
@@ -619,7 +619,7 @@ class BuildContainerTask(BaseTaskHandler):
             create_build_args['flatpak'] = True
         if skip_build:
             create_build_args['skip_build'] = True
-        if triggered_after_koji_task:
+        if triggered_after_koji_task is not None:
             create_build_args['triggered_after_koji_task'] = triggered_after_koji_task
 
         try:

--- a/tests/test_builder_containerbuild.py
+++ b/tests/test_builder_containerbuild.py
@@ -687,7 +687,8 @@ class TestBuilder(object):
         {'release': '13'},
         {'skip_build': True},
         {'skip_build': False},
-        {'triggered_after_koji_task': 12345}
+        {'triggered_after_koji_task': 12345},
+        {'triggered_after_koji_task': 0},
     ))
     def test_additional_args(self, tmpdir, log_upload_raises, orchestrator, additional_args):
         koji_task_id = 123


### PR DESCRIPTION
* OSBS-8150

Signed-off-by: Robert Cerven <rcerven@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
