### PR TITLE
Fix koji-build-id type

### DIFF
--- a/koji_containerbuild/plugins/cli_containerbuild.py
+++ b/koji_containerbuild/plugins/cli_containerbuild.py
@@ -179,6 +179,7 @@ def parse_source_arguments(options, args):
                       help=_("Signing intent of the ODCS composes [default: %default]."),
                       default=None, dest='signing_intent')
     parser.add_option("--koji-build-id",
+                      type="int",
                       help=_("Koji build id for sources, "
                              "is required or koji-build-nvr is provided"))
     parser.add_option("--koji-build-nvr",

--- a/tests/test_cli_containerbuild.py
+++ b/tests/test_cli_containerbuild.py
@@ -95,7 +95,7 @@ def build_cli_args(target,
                    wait=None,
                    background=False,
                    build_type='container_build',
-                   koji_build_id=12345,
+                   koji_build_id='12345',
                    koji_build_nvr='test_nvr'):
     """Build command line arguments for cli_containerbuild.handle_build()"""
     if build_type == 'container_build' or build_type == 'flatpak_build':
@@ -316,7 +316,7 @@ class TestCLI(object):
 
         if koji_build_id:
             test_args.append('--koji-build-id')
-            test_args.append(koji_build_id)
+            test_args.append(str(koji_build_id))  # parser parses strings
             expected_opts['koji_build_id'] = koji_build_id
 
         if koji_build_nvr:


### PR DESCRIPTION
`koji-build-id` must be parsed as integer

* OSBS-8041

Signed-off-by: Martin Bašti <mbasti@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
