### PR TITLE
builder: describe the purpose of git_branch parameter

### DIFF
--- a/koji_containerbuild/plugins/builder_containerbuild.py
+++ b/koji_containerbuild/plugins/builder_containerbuild.py
@@ -583,7 +583,9 @@ class BuildContainerTask(BaseContainerTask):
                     },
                     "git_branch": {
                         "type": ["string", "null"],
-                        "description": "Git branch to build from."
+                        "description": "Git branch to build from. OSBS uses "
+                                       "this to determine which BuildConfig "
+                                       "to update."
                     },
                     "push_url": {
                         "type": ["string", "null"]


### PR DESCRIPTION
Prior to this change, it was not clear to users why they must specify the `git_branch` parameter, or how that differs from the buildContainer task's scm URL parameter.

Add more context to the `git_branch` description in the JSON schema.


Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Pull request includes link to an osbs-docs PR for user documentation updates