### PR TITLE
add custom userdata dictionary to args list

### DIFF
--- a/koji_containerbuild/plugins/builder_containerbuild.py
+++ b/koji_containerbuild/plugins/builder_containerbuild.py
@@ -619,7 +619,11 @@ class BuildContainerTask(BaseContainerTask):
                     "triggered_after_koji_task": {
                         "type": "integer",
                         "description": "Koji task for which autorebuild runs"
-                    }
+                    },
+                    "userdata": {
+                        "type": "object",
+                        "description": "User defined dictionary containing custom metadata",
+                    },
                 },
                 "additionalProperties": False
             }

--- a/koji_containerbuild/plugins/cli_containerbuild.py
+++ b/koji_containerbuild/plugins/cli_containerbuild.py
@@ -22,6 +22,8 @@
 
 from __future__ import print_function
 
+import json
+
 from koji.plugin import export_cli
 from koji_cli.lib import _, activate_session, parse_arches, \
                          OptionParser, watch_tasks, _running_in_bg
@@ -105,6 +107,8 @@ def parse_arguments(options, args, flatpak):
     parser.add_option("--skip-build", action="store_true",
                       help=_("Skip build and update buildconfig. "
                              "Use this option to update autorebuild settings"))
+    parser.add_option("--userdata",
+                      help=_("JSON dictionary of user defined custom metadata"))
     if not flatpak:
         parser.add_option("--release",
                           help=_("Set release value"))
@@ -132,7 +136,8 @@ def parse_arguments(options, args, flatpak):
     if not build_opts.git_branch:
         parser.error(_("git-branch must be specified"))
 
-    keys = ('scratch', 'yum_repourls', 'git_branch', 'signing_intent', 'compose_ids', 'skip_build')
+    keys = ('scratch', 'yum_repourls', 'git_branch', 'signing_intent', 'compose_ids', 'skip_build',
+            'userdata')
 
     if flatpak:
         opts['flatpak'] = True
@@ -149,6 +154,9 @@ def parse_arguments(options, args, flatpak):
         val = getattr(build_opts, key)
         if val is not None:
             opts[key] = val
+            if key == 'userdata':
+                opts[key] = json.loads(val)
+
     # create the parser in this function and return it to
     # simplify the unit test cases
     return build_opts, args, opts, parser

--- a/tests/test_cli_containerbuild.py
+++ b/tests/test_cli_containerbuild.py
@@ -16,6 +16,7 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
+import json
 import pytest
 from flexmock import flexmock
 from collections import OrderedDict
@@ -188,10 +189,11 @@ class TestCLI(object):
         (True, None, None, None, None),
         (True, None, 'parent_build', None, None),
     ))
+    @pytest.mark.parametrize('userdata', [None, {'custom': 'userdata'}])
     def test_cli_container_args(self, tmpdir, scratch, wait, quiet,
                                 repo_url, git_branch, channel_override, release,
                                 isolated, koji_parent_build, flatpak, compose_ids,
-                                signing_intent):
+                                signing_intent, userdata):
         options = flexmock(allowed_scms='pkgs.example.com:/*:no')
         options.quiet = False
         test_args = ['test', 'source_repo://image#ref']
@@ -254,6 +256,11 @@ class TestCLI(object):
             test_args.append('--signing-intent')
             test_args.append(signing_intent)
             expected_opts['signing_intent'] = signing_intent
+
+        if userdata:
+            test_args.append('--userdata')
+            test_args.append(json.dumps(userdata))
+            expected_opts['userdata'] = userdata
 
         build_opts, parsed_args, opts, _ = parse_arguments(options, test_args, flatpak=flatpak)
         expected_quiet = quiet or options.quiet


### PR DESCRIPTION
fixes osbs-8024

Add a custom userdata dictionary to the optional arguments

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
