### PR TITLE
Generate build_annotations.json file

### DIFF
--- a/koji-containerbuild.spec
+++ b/koji-containerbuild.spec
@@ -70,8 +70,10 @@ Requires:   python-urlgrabber
 Requires:   python-dockerfile-parse
 %if 0%{with python3}
 Requires:   python3-jsonschema
+Requires:   python3-six
 %else
 Requires:   python2-jsonschema
+Requires:   python-six
 %endif
 
 %description builder
@@ -170,6 +172,9 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
+* Tue Dec 10 2019 Athos Ribeiro <athos@redhat.com>
+- Require python-six for builder plugin
+
 * Tue Dec 10 2019 Robert Cerven <rcerven@redhat.com> 0.7.18-1
 - Enable shellcheck (bash) lint (mbasti@redhat.com)
 - Fail build for existing build if build state isn't failed or canceled, which

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 jsonschema
+six


### PR DESCRIPTION
Search for a 'koji_task_annotations_whitelist' list in the OpenShift
build annotations. Use its values to select possible keys in the build
annotations dict to include in a 'build_annotations.json' file to be
attached to the koji task. If an empty file would be generated, do not
generate the file.

* OSBS-8138

Signed-off-by: Athos Ribeiro <athos@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
