### PR TITLE
don't check for build nvr existance for autorebuilds which have 'trig…

### DIFF
--- a/koji_containerbuild/plugins/builder_containerbuild.py
+++ b/koji_containerbuild/plugins/builder_containerbuild.py
@@ -867,6 +867,12 @@ class BuildContainerTask(BaseContainerTask):
         if not SCM.is_scm_url(src):
             raise koji.BuildError('Invalid source specification: %s' % src)
 
+        # don't check build nvr for autorebuild as they might be using
+        # add_timestamp_to_release
+        triggered_after_koji_task = opts.get('triggered_after_koji_task', None)
+        if triggered_after_koji_task:
+            expected_nvr = None
+
         # Scratch and auto release builds shouldn't be checked for nvr
         if not self.opts.get('scratch') and expected_nvr:
             try:

--- a/tests/test_builder_containerbuild.py
+++ b/tests/test_builder_containerbuild.py
@@ -1143,28 +1143,36 @@ class TestBuilder(object):
             }
 
     @pytest.mark.parametrize('orchestrator', (True, False))
-    @pytest.mark.parametrize(('build_state', 'build_fails'), (
-        ('COMPLETE', True),
-        ('FAILED', False),
-        ('CANCELED', False),
+    @pytest.mark.parametrize(('build_state', 'triggered_after_koji_task', 'build_fails'), (
+        ('COMPLETE', True, False),
+        ('COMPLETE', False, True),
+        ('FAILED', True, False),
+        ('FAILED', False, False),
+        ('CANCELED', True, False),
+        ('CANCELED', False, False),
     ))
     @pytest.mark.parametrize(('df_release', 'param_release', 'expected'), (
         ('10', '11', '11'),
         (None, '11', '11'),
         ('10', None, '10'),
     ))
-    def test_build_nvr_exists(self, tmpdir, orchestrator, build_state, build_fails,
-                              df_release, param_release, expected):
+    def test_build_nvr_exists(self, tmpdir, orchestrator, build_state, triggered_after_koji_task,
+                              build_fails, df_release, param_release, expected):
         koji_task_id = 123
         last_event_id = 456
         koji_build_id = 999
 
         session = self._mock_session(last_event_id, koji_task_id)
 
-        (session
-            .should_receive('getBuild')
-            .with_args('fedora-docker-25-%s' % expected)
-            .and_return({'id': last_event_id, 'state': koji.BUILD_STATES[build_state]}))
+        if triggered_after_koji_task:
+            (session
+                .should_receive('getBuild')
+                .never())
+        else:
+            (session
+                .should_receive('getBuild')
+                .with_args('fedora-docker-25-%s' % expected)
+                .and_return({'id': last_event_id, 'state': koji.BUILD_STATES[build_state]}))
 
         dockerfile_content = dedent("""\
             FROM fedora
@@ -1204,6 +1212,9 @@ class TestBuilder(object):
         additional_args = {}
         if param_release:
             additional_args['release'] = param_release
+        if triggered_after_koji_task:
+            additional_args['triggered_after_koji_task'] = 12345
+
         task._osbs = self._mock_osbs(koji_build_id=koji_build_id,
                                      src=src,
                                      koji_task_id=koji_task_id,


### PR DESCRIPTION
…gered_after_koji_task',

as they might be using add_timestamp_to_release, so the nvr from
Dockerfile isn't the build nvr which will be created

* OSBS-8377

Signed-off-by: Robert Cerven <rcerven@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
