### PR TITLE
use orchestrator.log name for log in task for source container

### DIFF
--- a/koji_containerbuild/plugins/builder_containerbuild.py
+++ b/koji_containerbuild/plugins/builder_containerbuild.py
@@ -279,6 +279,7 @@ class BaseContainerTask(BaseTaskHandler):
         self._osbs = None
         self.demux = None
         self._log_handler_added = False
+        self.incremental_log_basename = 'openshift-incremental.log'
 
     def osbs(self):
         """Handler of OSBS object"""
@@ -345,10 +346,9 @@ class BaseContainerTask(BaseTaskHandler):
             watcher.clean()
 
     def _write_combined_log(self, build_id, logs_dir):
-        log_basename = 'openshift-incremental.log'
-        log_filename = os.path.join(logs_dir, log_basename)
+        log_filename = os.path.join(logs_dir, self.incremental_log_basename)
 
-        self.logger.info("Will write follow log: %s", log_basename)
+        self.logger.info("Will write follow log: %s", self.incremental_log_basename)
         try:
             log = self.osbs().get_build_logs(build_id, follow=True)
         except Exception as error:
@@ -364,7 +364,7 @@ class BaseContainerTask(BaseTaskHandler):
                                                                        error)
                 raise ContainerError(msg)
 
-        self.logger.info("%s written", log_basename)
+        self.logger.info("%s written", self.incremental_log_basename)
 
     def _write_demultiplexed_logs(self, build_id, logs_dir):
         self.logger.info("Will write demuxed logs in: %s/", logs_dir)
@@ -1013,9 +1013,9 @@ class BuildSourceContainerTask(BaseContainerTask):
     }
 
     def __init__(self, id, method, params, session, options, workdir=None, demux=False):
-        BaseContainerTask.__init__(self, id, method, params, session, options,
-                                   workdir)
+        BaseContainerTask.__init__(self, id, method, params, session, options, workdir)
         self.demux = demux
+        self.incremental_log_basename = 'orchestrator.log'
 
     def createSourceContainer(self, target_info=None, scratch=None, component=None,
                               koji_build_id=None, koji_build_nvr=None, signing_intent=None):

--- a/tests/test_builder_containerbuild.py
+++ b/tests/test_builder_containerbuild.py
@@ -126,18 +126,21 @@ class TestBuilder(object):
             with open(logfile_path) as log_file:
                 assert log_file.read() == logs_content
 
-    def _check_non_orchestrator_logs(self, log_entries, logs_dir):
+    def _check_non_orchestrator_logs(self, log_entries, logs_dir, source):
         logs_content = ''.join(line + '\n' for line in log_entries)
-        logfile_path = os.path.join(logs_dir, 'openshift-incremental.log')
+        if source:
+            logfile_path = os.path.join(logs_dir, 'orchestrator.log')
+        else:
+            logfile_path = os.path.join(logs_dir, 'openshift-incremental.log')
         with open(logfile_path) as log_file:
             assert log_file.read() == logs_content
 
-    def _check_logfiles(self, log_entries, logs_dir, orchestrator):
+    def _check_logfiles(self, log_entries, logs_dir, orchestrator, source=False):
         # check that all the log entries for a build are where they are supposed to be
         if orchestrator:
             self._check_orchestrator_logs(log_entries, logs_dir)
         else:
-            self._check_non_orchestrator_logs(log_entries, logs_dir)
+            self._check_non_orchestrator_logs(log_entries, logs_dir, source=source)
 
     @pytest.mark.parametrize('orchestrator', [False, True])
     @pytest.mark.parametrize('get_logs_exc', [None, Exception('error')])
@@ -265,7 +268,7 @@ class TestBuilder(object):
             cct._write_incremental_logs('id', str(tmpdir))
 
         if get_logs_exc is None:
-            self._check_logfiles(log_entries, str(tmpdir), False)
+            self._check_logfiles(log_entries, str(tmpdir), False, source=True)
 
     def _mock_session(self, last_event_id, koji_task_id, pkg_info=USE_DEFAULT_PKG_INFO):
         if pkg_info == USE_DEFAULT_PKG_INFO:


### PR DESCRIPTION
* OSBS-8378

Signed-off-by: Robert Cerven <rcerven@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [ ] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
