### PR TITLE
Handle whitelist annotation as a string

### DIFF
--- a/koji_containerbuild/plugins/builder_containerbuild.py
+++ b/koji_containerbuild/plugins/builder_containerbuild.py
@@ -456,7 +456,8 @@ class BaseContainerTask(BaseTaskHandler):
 
     def upload_build_annotations(self, build_response):
         annotations = build_response.get_annotations() or {}
-        whitelist = annotations.get('koji_task_annotations_whitelist', [])
+        whitelist_str = annotations.get('koji_task_annotations_whitelist', "[]")
+        whitelist = json.loads(whitelist_str)
         task_annotations = {k: v for k, v in annotations.items() if k in whitelist}
         if task_annotations:
             f = StringIO()

--- a/tests/test_builder_containerbuild.py
+++ b/tests/test_builder_containerbuild.py
@@ -1689,14 +1689,14 @@ class TestBuilder(object):
 
     @pytest.mark.parametrize('annotations', (
         {},
-        {'koji_task_annotations_whitelist': []},
-        {'koji_task_annotations_whitelist': [], 'remote_source_url': 'stub_url'},
-        {'koji_task_annotations_whitelist': ['remote_source_url'],
+        {'koji_task_annotations_whitelist': '[]'},
+        {'koji_task_annotations_whitelist': '[]', 'remote_source_url': 'stub_url'},
+        {'koji_task_annotations_whitelist': '["remote_source_url"]',
          'remote_source_url': 'stub_url'},
         {'remote_source_url': 'stub_url'},
         {'a': '1', 'b': '2'},
-        {'koji_task_annotations_whitelist': ['a', 'b'], 'a': '1', 'b': '2', 'c': '3'},
-        {'koji_task_annotations_whitelist': ['a', 'b'], 'a': '1', 'c': '3'}
+        {'koji_task_annotations_whitelist': '["a", "b"]', 'a': '1', 'b': '2', 'c': '3'},
+        {'koji_task_annotations_whitelist': '["a", "b"]', 'a': '1', 'c': '3'}
         ))
     def test_upload_annotations(self, tmpdir, annotations):
         def mock_incremental_upload(session, fname, fd, uploadpath, logger=None):
@@ -1719,6 +1719,9 @@ class TestBuilder(object):
         build_result.should_receive('get_annotations').and_return(annotations)
         cct.upload_build_annotations(build_result)
         whitelist = annotations.get('koji_task_annotations_whitelist')
+        if whitelist:
+            whitelist = json.loads(whitelist)
+
         if not whitelist or len(annotations) < 2:
             assert not os.path.exists(annotations_file)
         else:


### PR DESCRIPTION
The OpenShift build annotation is set as a string. It should be handled
as such and converted to a list, if needed.

* OSBS-8138

Signed-off-by: Athos Ribeiro <athos@redhat.com>



Maintainers will complete the following section:
- [ ] Commit messages are descriptive enough
- [ ] "Signed-off-by:" line is present in each commit
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
