### PR TITLE
Fix dependency error in test script

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -84,6 +84,11 @@ if [[ $OS != "fedora" ]]; then
   $RUN $PYTHON get-pip.py
 fi
 
+# https://github.com/jaraco/zipp/issues/28
+if [[ $PYTHON_VERSION == 2 ]]; then
+  $RUN $PIP install zipp==1.0.0
+fi
+
 # Install koji-containerbuild
 $RUN $PYTHON setup.py install
 


### PR DESCRIPTION
The zipp distribution is pulled in in our dependency chain for CI runs.
This distribution recently dropped the python 2 support. We need to
fetch an older version of this dependency for python 2 runs.

* https://github.com/jaraco/zipp/issues/28

Signed-off-by: Athos Ribeiro <athos@redhat.com>



Maintainers will complete the following section:
- [ ] Commit messages are descriptive enough
- [ ] "Signed-off-by:" line is present in each commit
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
