### PR TITLE
Remove urlgrabber dependency

### DIFF
--- a/koji-containerbuild.spec
+++ b/koji-containerbuild.spec
@@ -66,7 +66,6 @@ Group:      Applications/System
 Requires:   koji-builder
 Requires:   koji-containerbuild
 Requires:   osbs-client
-Requires:   python-urlgrabber
 Requires:   python-dockerfile-parse
 %if 0%{with python3}
 Requires:   python3-jsonschema


### PR DESCRIPTION
This dependency is unused from 2016 :-/

Signed-off-by: Martin Bašti <mbasti@redhat.com>



Maintainers will complete the following section:
- [ ] Commit messages are descriptive enough
- [ ] "Signed-off-by:" line is present in each commit
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
