### PR TITLE
allow compose_ids used together with repo_url

### DIFF
--- a/koji_containerbuild/plugins/builder_containerbuild.py
+++ b/koji_containerbuild/plugins/builder_containerbuild.py
@@ -688,9 +688,6 @@ class BuildContainerTask(BaseContainerTask):
         if signing_intent and compose_ids:
             raise koji.BuildError("signing_intent used with compose_ids")
 
-        if compose_ids and yum_repourls:
-            raise koji.BuildError("compose_ids used with repo_url")
-
         create_build_args = {
             'git_uri': git_uri,
             'git_ref': scm.revision,

--- a/tests/test_builder_containerbuild.py
+++ b/tests/test_builder_containerbuild.py
@@ -1334,7 +1334,7 @@ class TestBuilder(object):
         ({'compose_ids': [1, 2]}, False),
         ({'signing_intent': 'intent1'}, False),
         ({'compose_ids': [1, 2], 'signing_intent': 'intent1'}, True),
-        ({'compose_ids': [1, 2], 'yum_repourls': ['www.repo.com']}, True)
+        ({'compose_ids': [1, 2], 'yum_repourls': ['www.repo.com']}, False)
     ))
     def test_compose_ids_and_signing_intent(self, tmpdir, additional_args, raises):
         koji_task_id = 123


### PR DESCRIPTION
* OSBS-8675

Signed-off-by: Robert Cerven <rcerven@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
