### PR TITLE
Revert "Allow additional properties for containerbuild"

### DIFF
--- a/koji_containerbuild/plugins/builder_containerbuild.py
+++ b/koji_containerbuild/plugins/builder_containerbuild.py
@@ -650,7 +650,8 @@ class BuildContainerTask(BaseContainerTask):
                         "type": "object",
                         "description": "User defined dictionary containing custom metadata",
                     },
-                }
+                },
+                "additionalProperties": False
             }
         ],
         "minItems": 3


### PR DESCRIPTION
OSBS-8455

Return to the strict validation of options.

This reverts commit 48669bdf190af6a70982e6c0870fc5cba9956184.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>

Maintainers will complete the following section:
- [ ] Commit messages are descriptive enough
- [ ] "Signed-off-by:" line is present in each commit
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
