### PR TITLE
packit: don't propose downstream update

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -5,12 +5,6 @@ downstream_package_name: koji-containerbuild
 
 # for packit service (Github app)
 jobs:
-- job: sync_from_downstream
-  trigger: commit
-- job: propose_downstream
-  trigger: release
-  metadata:
-    dist-git-branch: fedora-all
 - job: copr_build
   trigger: pull_request
   metadata:


### PR DESCRIPTION
We are not there yet, packit only creates issues github about failures

Signed-off-by: Martin Bašti <mbasti@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
