### PR TITLE
fix: add custom builder for tito

### DIFF
--- a/rel-eng/lib/builder.py
+++ b/rel-eng/lib/builder.py
@@ -1,0 +1,8 @@
+from tito.builder import Builder
+
+
+class KojiContainerBuilder(Builder):
+
+    def _get_tgz_name_and_ver(self):
+        """ Returns name of tgz created by tito """
+        return "%s" % self.display_version

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -1,6 +1,7 @@
 [buildconfig]
-builder = tito.builder.Builder
+builder = builder.KojiContainerBuilder
 tagger = tito.tagger.VersionTagger
 changelog_do_not_remove_cherrypick = 0
 changelog_format = %s (%ae)
 tag_format = {version}
+lib_dir = rel-eng/lib


### PR DESCRIPTION
Tito by default is creating new tarballs as {project-name}-{version}. This is a problem when Source0 contains only {version}.

Signed-off-by: Martin Styk <mastyk@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
