### PR TITLE
fix: update tito builder to match with expected value in %setup

### DIFF
--- a/rel-eng/lib/builder.py
+++ b/rel-eng/lib/builder.py
@@ -3,6 +3,10 @@ from tito.builder import Builder
 
 class KojiContainerBuilder(Builder):
 
-    def _get_tgz_name_and_ver(self):
-        """ Returns name of tgz created by tito """
-        return "%s" % self.display_version
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        # tarball has to represent Source0
+        # but internal structure should remain same
+        # i.e. {name}-{version} otherwise %setup -q
+        # will fail
+        self.tgz_filename = self.display_version + ".tar.gz"


### PR DESCRIPTION
Fix all corner cases in Tito.
You can verify this patch as following:
- `tito build --rpm`
- `tito build --rpm --test`

Signed-off-by: Martin Styk <mastyk@redhat.com>

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
