### PR TITLE
fix: tito py2 support

### DIFF
--- a/rel-eng/lib/osbsbuilder.py
+++ b/rel-eng/lib/osbsbuilder.py
@@ -4,7 +4,7 @@ from tito.builder import Builder
 class KojiContainerBuilder(Builder):
 
     def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+        super(KojiContainerBuilder, self).__init__(**kwargs)
         # tarball has to represent Source0
         # but internal structure should remain same
         # i.e. {name}-{version} otherwise %setup -q

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -1,5 +1,5 @@
 [buildconfig]
-builder = builder.KojiContainerBuilder
+builder = osbsbuilder.KojiContainerBuilder
 tagger = tito.tagger.VersionTagger
 changelog_do_not_remove_cherrypick = 0
 changelog_format = %s (%ae)


### PR DESCRIPTION
* module must be named differently than builder.py, otherwise tito
  is trying use tito.builder instead on py2
* fix super() to be python2 compat

Signed-off-by: Martin Bašti <mbasti@redhat.com>



Maintainers will complete the following section:
- [ ] Commit messages are descriptive enough
- [ ] "Signed-off-by:" line is present in each commit
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
