### PR TITLE
Replace "Signed-off-by:" maintainer task with DCO...

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,7 +1,6 @@
 # Maintainers will complete the following section
 
 - [ ] Commit messages are descriptive enough
-- [ ] "Signed-off-by:" line is present in each commit
 - [ ] Code coverage from testing does not decrease and new code is covered
 - [ ] JSON/YAML configuration changes are updated in the relevant schema
 - [ ] Pull request has a link to an osbs-docs PR for user documentation updates


### PR DESCRIPTION
...GitHub Action

* CLOUDBLD-766

Signed-off-by: Ben Alkov <ben.alkov@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
