### PR TITLE
builder: document space delimiter for arch_override

### DIFF
--- a/koji_containerbuild/plugins/builder_containerbuild.py
+++ b/koji_containerbuild/plugins/builder_containerbuild.py
@@ -607,7 +607,8 @@ class BuildContainerTask(BaseContainerTask):
                     },
                     "arch_override": {
                         "type": ["string", "null"],
-                        "description": "Limit build to specific arches"
+                        "description": "Limit build to specific arches. "
+                                       "Separate each arch with a space."
                     },
                     "git_branch": {
                         "type": ["string", "null"],


### PR DESCRIPTION
When a client calls the `buildContainer` RPC with the `arch_override` option, the client must separate each architecture name with at least one whitespace character, because we call `split()` on this string.

This requirement is slightly different than the container-build CLI plugin or other Koji APIs, because in the container-build CLI, we call Koji's `parse_arches()` method, which handles commas or spaces.

Explain this requirement in the JSON schema.

Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Pull request has a link to an osbs-docs PR for user documentation updates