### PR TITLE
pyrsistent support for Py 2 ends with release 0.16...

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -119,6 +119,12 @@ RUN="$ENGINE exec -ti $CONTAINER_NAME"
     $RUN $PIP install configparser==4.0.2
   fi
 
+  # pyrsistent >= 0.17 no longer supports python 2
+  # pyrsistent is a dependency of jsonschema
+  if [[ $PYTHON_VERSION == 2 ]]; then
+    $RUN $PIP install 'pyrsistent==0.16.*'
+  fi
+
   # Install koji-containerbuild
   $RUN $PYTHON setup.py install
 


### PR DESCRIPTION
...CI on Cent is broken

This MR pins test.sh's pyrsistent<0.17 based on https://github.com/tobgu/pyrsistent/issues/214

Signed-off-by: Ben Alkov <ben.alkov@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
