### PR TITLE
'pytest-capturelog' is dead and must be removed

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,3 @@
 flexmock>=0.10.3
 pytest>=4.1.0
-pytest-capturelog
 pytest-cov


### PR DESCRIPTION
Signed-off-by: Ben Alkov <ben.alkov@redhat.com>

- CLOUDBLD-3156

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
