### PR TITLE
New option --operator-csv-modifications-url

### DIFF
--- a/koji_containerbuild/plugins/builder_containerbuild.py
+++ b/koji_containerbuild/plugins/builder_containerbuild.py
@@ -660,6 +660,10 @@ class BuildContainerTask(BaseContainerTask):
                         "type": "object",
                         "description": "User defined dictionary containing custom metadata",
                     },
+                    "operator_csv_modifications_url": {
+                        "type": ["string", "null"],
+                        "description": "URL to JSON file with operator CSV modifications",
+                    }
                 },
                 "additionalProperties": False
             }
@@ -679,7 +683,7 @@ class BuildContainerTask(BaseContainerTask):
                         branch=None, push_url=None, koji_parent_build=None,
                         release=None, flatpak=False, signing_intent=None,
                         compose_ids=None, skip_build=False, triggered_after_koji_task=None,
-                        dependency_replacements=None):
+                        dependency_replacements=None, operator_csv_modifications_url=None):
         if not yum_repourls:
             yum_repourls = []
 
@@ -722,6 +726,8 @@ class BuildContainerTask(BaseContainerTask):
             create_build_args['skip_build'] = True
         if triggered_after_koji_task is not None:
             create_build_args['triggered_after_koji_task'] = triggered_after_koji_task
+        if operator_csv_modifications_url:
+            create_build_args['operator_csv_modifications_url'] = operator_csv_modifications_url
 
         orchestrator_create_build_args = create_build_args.copy()
         orchestrator_create_build_args['platforms'] = arches

--- a/koji_containerbuild/plugins/cli_containerbuild.py
+++ b/koji_containerbuild/plugins/cli_containerbuild.py
@@ -112,6 +112,12 @@ def parse_arguments(options, args, flatpak):
                              "Use this option to update autorebuild settings"))
     parser.add_option("--userdata",
                       help=_("JSON dictionary of user defined custom metadata"))
+    parser.add_option("--operator-csv-modifications-url",
+                      help=_("URL to JSON file with operator CSV modification"),
+                      action='store', default=None,
+                      dest='operator_csv_modifications_url', metavar='URL',
+                      )
+
     if not flatpak:
         parser.add_option("--release",
                           help=_("Set release value"))
@@ -135,12 +141,22 @@ def parse_arguments(options, args, flatpak):
     if build_opts.signing_intent and build_opts.compose_ids:
         parser.error(_("--signing-intent cannot be used with --compose-id"))
 
+    if build_opts.operator_csv_modifications_url and not build_opts.isolated:
+        parser.error(_("Only --isolated builds support option --operator-csv-modifications-url"))
+
+    if (
+        build_opts.operator_csv_modifications_url and
+        '://' not in build_opts.operator_csv_modifications_url
+    ):
+        parser.error(_("Value provided to --operator-csv-modifications-url "
+                       "does not look like an URL"))
+
     opts = {}
     if not build_opts.git_branch:
         parser.error(_("git-branch must be specified"))
 
     keys = ('scratch', 'yum_repourls', 'git_branch', 'signing_intent', 'compose_ids', 'skip_build',
-            'userdata', 'dependency_replacements')
+            'userdata', 'dependency_replacements', 'operator_csv_modifications_url')
 
     if flatpak:
         opts['flatpak'] = True


### PR DESCRIPTION
Option can pass URL to JSON file with modifications to operator CSV
file.

Can be used only with --isolated option

* CLOUDBLD-3976

Signed-off-by: Martin Bašti <mbasti@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
