### PR TITLE
add task signatures to koji.task.LEGACY_SIGNATURES

### DIFF
--- a/koji_containerbuild/plugins/hub_containerbuild.py
+++ b/koji_containerbuild/plugins/hub_containerbuild.py
@@ -26,6 +26,7 @@ import sys
 import logging
 
 import koji
+import koji.tasks
 from koji.context import context
 from koji.plugin import export
 
@@ -34,6 +35,12 @@ sys.path.insert(0, koji_hub_path)
 import kojihub  # noqa: E402 # pylint: disable=import-error
 
 logger = logging.getLogger('koji.plugins')
+
+# update task signatures, so they can properly parse options for policies
+koji.tasks.LEGACY_SIGNATURES['buildContainer'] = [[['src', 'target', 'opts'],
+                                                  None, None, (None,)]]
+koji.tasks.LEGACY_SIGNATURES['buildSourceContainer'] = [[['target', 'opts'],
+                                                        None, None, (None,)]]
 
 
 def _get_task_opts_and_opts(opts, priority, channel):


### PR DESCRIPTION
koji policies can use src/target in policy checks
if mapping for these exists in the hub.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
