### PR TITLE
Drop importlib_metadata from requirements.txt as it causes dependency issues; install via test.sh

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-importlib_metadata<3
 jsonschema
 six

--- a/test.sh
+++ b/test.sh
@@ -112,7 +112,13 @@ function setup_kojic() {
     # pyrsistent >= 0.17 no longer supports python 2
     # pyrsistent is a dependency of jsonschema
     $RUN "${PIP_INST[@]}" 'pyrsistent==0.16.*'
+
+    # setuptools_scm >= 6 no longer supports python 2
+    $RUN "${PIP_INST[@]}" 'setuptools_scm<6'
   fi
+
+  # Workaround problems with dependency hell for older Pythons
+  $RUN "${PIP_INST[@]}" -U 'importlib_metadata<3;python_version<"3.8"'
 
   # Setuptools install koji-c from source
   $RUN $PYTHON setup.py install


### PR DESCRIPTION
I'd update the imports in the code as well, but they are not here. I don't understand why was this dependency added in the first place, but the commit message mentions CentOS and Python 2, so maybe it fixes a transitive depndency on importlib_metadata there, yet this can be avoided on Python 3.8+

Relevant problem in Fedora: [nothing provides python3.9dist(importlib-metadata) < 3 needed by koji-containerbuild-0.11.0-2.fc35.noarch](https://bugzilla.redhat.com/show_bug.cgi?id=1940324)

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [n/a] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates