### PR TITLE
Fix: Fix passing operator_csv_modifications_url param to orchestrator

### DIFF
--- a/koji_containerbuild/plugins/builder_containerbuild.py
+++ b/koji_containerbuild/plugins/builder_containerbuild.py
@@ -957,6 +957,7 @@ class BuildContainerTask(BaseContainerTask):
             compose_ids=opts.get('compose_ids', None),
             skip_build=skip_build,
             triggered_after_koji_task=triggered_after_koji_task,
+            operator_csv_modifications_url=opts.get('operator_csv_modifications_url'),
         )
 
         results = []


### PR DESCRIPTION
Accidentally this parameter was not passed to orchestrator and thus
option was effectivelly ignored.

CLOUDBLD-3976

Signed-off-by: Martin Bašti <mbasti@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
