### PR TITLE
No more TODOs and FIXME in code

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -35,7 +35,6 @@ disable=I,
         broad-except,
         comprehension-escape, # throws false positives on 1.9.0 (Fedora 29)
         exception-escape, # throws false positives on 1.9.0 (Fedora 29)
-        fixme,
         import-outside-toplevel,
         invalid-name,
         keyword-arg-before-vararg,  # nice to have

--- a/koji_containerbuild/plugins/builder_containerbuild.py
+++ b/koji_containerbuild/plugins/builder_containerbuild.py
@@ -110,7 +110,6 @@ class ContainerCancelled(koji.GenericError):
     faultCode = 2002
 
 
-# TODO: push this to upstream koji
 class My_SCM(SCM):
     def get_component(self):
         component = os.path.basename(self.repository)
@@ -777,7 +776,6 @@ class BuildContainerTask(BaseContainerTask):
         buildconfig = self.session.getBuildConfig(build_tag, event=self.event_id)
         arches = buildconfig['arches']
         if not arches:
-            # XXX - need to handle this better
             raise koji.BuildError("No arches for tag %(name)s [%(id)s]" % buildconfig)
         tag_archlist = [koji.canonArch(a) for a in arches.split()]
         self.logger.debug('arches: %s', arches)


### PR DESCRIPTION
TODOs should be resolved before merging or issue trackers should be used
instead.

No one ever will go and fix TODOs, mainly if half of them is not valid
because code changes.

Signed-off-by: Martin Bašti <mbasti@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [n/a] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
