### PR TITLE
Pin jsonschema==3.2.0 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-jsonschema
+jsonschema==3.2.0
 six


### PR DESCRIPTION
pip is pulling in an alpha version which breaks on Py2

Signed-off-by: Ben Alkov <ben.alkov@redhat.com>

- CLOUDBLD-6030

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
