### PR TITLE
builder: document signing_intent parameter

### DIFF
--- a/koji_containerbuild/plugins/builder_containerbuild.py
+++ b/koji_containerbuild/plugins/builder_containerbuild.py
@@ -705,7 +705,14 @@ class BuildContainerTask(BaseContainerTask):
                     },
                     "signing_intent": {
                         "type": ["string", "null"],
-                        "description": "Signing intent of the ODCS composes."
+                        "description": "Signing intent of the ODCS composes. "
+                        "This must be one of the signing intent names "
+                        "configured on the OSBS server, or null. If this "
+                        "value is null (the default), the server will use the "
+                        "signing intent of the compose_ids you specify, or "
+                        "default_signing_intent. To view the full list of "
+                        "possible names, see REACTOR_CONFIG in "
+                        "orchestrator.log."
                     },
                     "skip_build": {
                         "type": "boolean",
@@ -1073,7 +1080,14 @@ class BuildSourceContainerTask(BaseContainerTask):
                     },
                     "signing_intent": {
                         "type": ["string"],
-                        "description": "Signing intent of the ODCS composes."
+                        "description": "Signing intent of the ODCS composes. "
+                        "This must be one of the signing intent names "
+                        "configured on the OSBS server, or null. If this "
+                        "value is null (the default), the server will use the "
+                        "signing intent of the compose_ids you specify, or "
+                        "default_signing_intent. To view the full list of "
+                        "possible names, see REACTOR_CONFIG in "
+                        "orchestrator.log."
                     },
                 },
                 "anyOf": [


### PR DESCRIPTION
Update the JSON schema for signing_intent to explain how users should use this field and how to discover the list of allowed values.

Fixes: https://github.com/containerbuildsystem/atomic-reactor/issues/1552