### PR TITLE
Bump required pytest version

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,5 @@
-flexmock>=0.10.3
-pytest>=4.1.0
+flexmock>=0.10.5
+pytest>=4.6.11
 pytest-cov
 pytest-html
 flake8


### PR DESCRIPTION
Fixes internal error cause by flexmock:

```
INTERNALERROR>   File "/usr/lib/python2.7/site-packages/flexmock.py", line 1249, in call_runtest_hook
1129
INTERNALERROR>     teardown.duration = ret.duration
INTERNALERROR> AttributeError: 'CallInfo' object has no attribute 'duration'
```

flexmock 0.10.5 requires newer pytest, but doesn't properly specifies
min requirements

Signed-off-by: Martin Basti <mbasti@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
