### PR TITLE
Freeze flexmock version to 0.10.4

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
-flexmock>=0.10.3
+flexmock==0.10.4
 pytest>=4.1.0
 pytest-cov
 pytest-html


### PR DESCRIPTION
Flexmock >= 0.10.5  doens't work with pytest version supporting py2

https://github.com/flexmock/flexmock/issues/46

Signed-off-by: Martin Basti <mbasti@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
