### PR TITLE
RPM: Fix py3 dependency

### DIFF
--- a/koji-containerbuild.spec
+++ b/koji-containerbuild.spec
@@ -55,11 +55,12 @@ Group:      Applications/System
 Requires:   koji-builder
 Requires:   koji-containerbuild
 Requires:   osbs-client
-Requires:   python-dockerfile-parse
 %if 0%{with python3}
+Requires:   python3-dockerfile-parse
 Requires:   python3-jsonschema
 Requires:   python3-six
 %else
+Requires:   python-dockerfile-parse
 Requires:   python2-jsonschema
 Requires:   python-six
 %endif

--- a/test.sh
+++ b/test.sh
@@ -72,7 +72,7 @@ function setup_kojic() {
   # from specified git source (default: upstream master)
   $RUN rm -rf /tmp/osbs-client
   $RUN git clone --depth 1 --single-branch \
-       https://github.com/projectatomic/osbs-client --branch master /tmp/osbs-client
+       https://github.com/projectatomic/osbs-client --branch osbs_ocp3 /tmp/osbs-client
   # RPM install build dependencies for osbs-client
   $RUN "${BUILDDEP[@]}" --define "with_python3 ${WITH_PY3}" -y /tmp/osbs-client/osbs-client.spec
 
@@ -87,7 +87,7 @@ function setup_kojic() {
   # This will also ensure all the deps are specified in the spec
   # Pip install osbs-client from git master
   $RUN "${PIP_INST[@]}" --upgrade --no-deps --force-reinstall \
-      git+https://github.com/projectatomic/osbs-client
+      git+https://github.com/projectatomic/osbs-client.git@osbs_ocp3
   # Pip install dockerfile-parse from git master
   $RUN "${PIP_INST[@]}" --upgrade --force-reinstall \
       git+https://github.com/containerbuildsystem/dockerfile-parse


### PR DESCRIPTION
Py3 dependencies starts with `python3-` in fedora, and we are already
building that RPM with python3- prefix

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
