### PR TITLE
pass userdata to osbs-client and also add it for source builds

### DIFF
--- a/koji_containerbuild/plugins/builder_containerbuild.py
+++ b/koji_containerbuild/plugins/builder_containerbuild.py
@@ -684,7 +684,8 @@ class BuildContainerTask(BaseContainerTask):
                         scratch=None, isolated=None, yum_repourls=None,
                         branch=None, koji_parent_build=None, release=None,
                         flatpak=False, signing_intent=None, compose_ids=None,
-                        dependency_replacements=None, operator_csv_modifications_url=None):
+                        dependency_replacements=None, operator_csv_modifications_url=None,
+                        userdata=None):
         if not yum_repourls:
             yum_repourls = []
 
@@ -722,6 +723,8 @@ class BuildContainerTask(BaseContainerTask):
             create_build_args['flatpak'] = True
         if operator_csv_modifications_url:
             create_build_args['operator_csv_modifications_url'] = operator_csv_modifications_url
+        if userdata:
+            create_build_args['userdata'] = userdata
         if signing_intent:
             create_build_args['signing_intent'] = signing_intent
         if compose_ids:
@@ -919,6 +922,7 @@ class BuildContainerTask(BaseContainerTask):
             signing_intent=opts.get('signing_intent', None),
             compose_ids=opts.get('compose_ids', None),
             operator_csv_modifications_url=opts.get('operator_csv_modifications_url'),
+            userdata=opts.get('userdata', None),
         )
 
         result = self.createContainer(**kwargs)
@@ -984,6 +988,10 @@ class BuildSourceContainerTask(BaseContainerTask):
                         "possible names, see REACTOR_CONFIG in "
                         "orchestrator.log."
                     },
+                    "userdata": {
+                        "type": "object",
+                        "description": "User defined dictionary containing custom metadata",
+                    },
                 },
                 "anyOf": [
                     {"required": ["koji_build_nvr"]},
@@ -1001,7 +1009,8 @@ class BuildSourceContainerTask(BaseContainerTask):
         self.event_id = None
 
     def createSourceContainer(self, target_info=None, scratch=None, component=None,
-                              koji_build_id=None, koji_build_nvr=None, signing_intent=None):
+                              koji_build_id=None, koji_build_nvr=None, signing_intent=None,
+                              userdata=None):
         this_task = self.session.getTaskInfo(self.id)
         self.logger.debug("This task: %r", this_task)
         owner_info = self.session.getUser(this_task['owner'])
@@ -1019,6 +1028,8 @@ class BuildSourceContainerTask(BaseContainerTask):
 
         if signing_intent:
             create_build_args['signing_intent'] = signing_intent
+        if userdata:
+            create_build_args['userdata'] = userdata
 
         try:
             create_method = self.osbs().create_source_container_build
@@ -1090,6 +1101,7 @@ class BuildSourceContainerTask(BaseContainerTask):
             koji_build_id=build_id,
             koji_build_nvr=build_nvr,
             signing_intent=opts.get('signing_intent', None),
+            userdata=opts.get('userdata', None),
         )
 
         result = self.createSourceContainer(**kwargs)

--- a/koji_containerbuild/plugins/cli_containerbuild.py
+++ b/koji_containerbuild/plugins/cli_containerbuild.py
@@ -208,6 +208,8 @@ def parse_source_arguments(options, args):
     parser.add_option("--koji-build-nvr",
                       help=_("Koji build nvr for sources, "
                              "is required or koji-build-id is provided"))
+    parser.add_option("--userdata",
+                      help=_("JSON dictionary of user defined custom metadata"))
 
     build_opts, args = parser.parse_args(args)
 
@@ -218,12 +220,14 @@ def parse_source_arguments(options, args):
         parser.error(_("at least one of --koji-build-id and --koji-build-nvr has to be specified"))
 
     opts = {}
-    keys = ('scratch', 'signing_intent', 'koji_build_id', 'koji_build_nvr')
+    keys = ('scratch', 'signing_intent', 'koji_build_id', 'koji_build_nvr', 'userdata')
 
     for key in keys:
         val = getattr(build_opts, key)
         if val is not None:
             opts[key] = val
+            if key == 'userdata':
+                opts[key] = json.loads(val)
     # create the parser in this function and return it to
     # simplify the unit test cases
     return build_opts, args, opts, parser

--- a/tests/test_builder_containerbuild.py
+++ b/tests/test_builder_containerbuild.py
@@ -324,6 +324,9 @@ class TestBuilder(object):
         if not create_build_args.get('signing_intent'):
             create_build_args.pop('signing_intent', None)
 
+        if not create_build_args.get('userdata'):
+            create_build_args.pop('userdata', None)
+
         if source:
             (flexmock(osbs.api.OSBS)
                 .should_receive('create_source_container_build')
@@ -853,6 +856,8 @@ class TestBuilder(object):
         {'isolated': True},
         {'isolated': False},
         {'release': '13'},
+        {'userdata': {'custom': 'userdata'}},
+        {'userdata': {}},
     ))
     def test_additional_args(self, tmpdir, log_upload_raises, additional_args):
         koji_task_id = 123
@@ -912,6 +917,8 @@ class TestBuilder(object):
         {'signing_intent': 'some intent', 'koji_build_nvr': 'build_nvr'},
         {'signing_intent': 'some intent', 'koji_build_nvr': 'build_nvr', 'koji_build_id': 12345},
         {'koji_build_nvr': 'build_nvr', 'koji_build_id': 12345},
+        {'userdata': {'custom': 'userdata'}, 'koji_build_id': 12345},
+        {'userdata': {}, 'koji_build_id': 12345},
     ))
     def test_additional_args_source(self, log_upload_raises, additional_args):
         koji_task_id = 123

--- a/tests/test_cli_containerbuild.py
+++ b/tests/test_cli_containerbuild.py
@@ -314,8 +314,9 @@ class TestCLI(object):
         (None, 12345, 'build_nvr'),
         (True, 12345, 'build_nvr'),
     ))
+    @pytest.mark.parametrize('userdata', [None, {'custom': 'userdata'}])
     def test_cli_source_args(self, wait, quiet, channel_override,
-                             signing_intent, scratch, koji_build_id, koji_build_nvr):
+                             signing_intent, scratch, koji_build_id, koji_build_nvr, userdata):
         options = flexmock(allowed_scms='pkgs.example.com:/*:no')
         options.quiet = False
         test_args = ['test']
@@ -352,6 +353,11 @@ class TestCLI(object):
             test_args.append('--signing-intent')
             test_args.append(signing_intent)
             expected_opts['signing_intent'] = signing_intent
+
+        if userdata:
+            test_args.append('--userdata')
+            test_args.append(json.dumps(userdata))
+            expected_opts['userdata'] = userdata
 
         build_opts, parsed_args, opts, _ = parse_source_arguments(options, test_args)
         expected_quiet = quiet or options.quiet


### PR DESCRIPTION
* CLOUDBLD-7986

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
