### PR TITLE
When pipeline run didn't succeeded and also didn't finish, cancel it

### DIFF
--- a/koji_containerbuild/plugins/builder_containerbuild.py
+++ b/koji_containerbuild/plugins/builder_containerbuild.py
@@ -537,6 +537,14 @@ class BaseContainerTask(BaseTaskHandler):
 
         elif not has_succeeded:
             error_message = self.osbs().get_build_error_message(build_id)
+
+            if self.osbs().build_not_finished(build_id):
+                try:
+                    self.osbs().cancel_build(build_id)
+                except Exception as ex:
+                    self.logger.error("Error during canceling pipeline run %s: %s",
+                                      build_id, repr(ex))
+
             if error_message:
                 raise ContainerError('Image build failed. %s. OSBS build id: %s' %
                                      (error_message, build_id))


### PR DESCRIPTION
* CLOUDBLD-8220

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
