### PR TITLE
upload last osbs-client.log updates

### DIFF
--- a/tests/test_builder_containerbuild.py
+++ b/tests/test_builder_containerbuild.py
@@ -659,6 +659,7 @@ class TestBuilder(object):
         if reason == 'signal_cancelled':
             task._incremental_upload_logs = \
                 lambda pid: os.kill(os.getpid(), signal.SIGINT)
+            flexmock(task).should_receive('_upload_logs_once').once().and_return(None)
             (flexmock(osbs.api.OSBS).should_receive('cancel_build').once())
 
         if reason == 'signal_cancelled' or reason == 'build_cancelled':
@@ -715,6 +716,7 @@ class TestBuilder(object):
         if reason == 'signal_cancelled':
             task._incremental_upload_logs = \
                 lambda pid: os.kill(os.getpid(), signal.SIGINT)
+            flexmock(task).should_receive('_upload_logs_once').once().and_return(None)
             (flexmock(osbs.api.OSBS).should_receive('cancel_build').once())
 
         if reason == 'signal_cancelled' or reason == 'build_cancelled':


### PR DESCRIPTION
Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- N/A JSON/YAML configuration changes are updated in the relevant schema
- N/A Pull request has a link to an osbs-docs PR for user documentation updates
