### PR TITLE
call wait_for_build_to_finish after reading logs finished, as there is

### DIFF
--- a/koji_containerbuild/plugins/builder_containerbuild.py
+++ b/koji_containerbuild/plugins/builder_containerbuild.py
@@ -527,6 +527,9 @@ class BaseContainerTask(BaseTaskHandler):
         # so we have to collect them back when the process ends
         user_warnings = self._read_user_warnings(osbs_logs_dir)
 
+        # there is race between all pods finished and pipeline run changing status
+        self.osbs().wait_for_build_to_finish(build_id)
+
         has_succeeded = self.osbs().build_has_succeeded(build_id)
         annotations = self.osbs().get_build_annotations(build_id)
         labels = self.osbs().get_build_labels(build_id)

--- a/tests/test_builder_containerbuild.py
+++ b/tests/test_builder_containerbuild.py
@@ -368,6 +368,7 @@ class TestBuilder(object):
         (flexmock(osbs.api.OSBS)
             .should_receive('get_build_error_message')
             .and_return("build error"))
+        (flexmock(osbs.api.OSBS).should_receive('wait_for_build_to_finish').and_return(None))
 
     def _mock_folders(self, tmpdir, dockerfile_content=None, additional_tags_content=None):
         if dockerfile_content is None:


### PR DESCRIPTION
race between all pods finished and pipeline run status changed

* CLOUDBLD-8359

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
