### PR TITLE
change default channel for buildSourceContainer to container-source

### DIFF
--- a/koji_containerbuild/plugins/hub_containerbuild.py
+++ b/koji_containerbuild/plugins/hub_containerbuild.py
@@ -77,8 +77,7 @@ def buildContainer(src, target, opts=None, priority=None, channel='container'):
                          priority so that Koji processes this ahead of other
                          tasks. Only Koji admins may specify a negative
                          priority.
-    :param str channel: the channel to allocate the task to (defaults to the
-                        "container" channel)
+    :param str channel: the channel to allocate the task to
     :returns: the task ID (integer)
     """
     new_opts, taskOpts = _get_task_opts_and_opts(opts, priority, channel)
@@ -86,7 +85,7 @@ def buildContainer(src, target, opts=None, priority=None, channel='container'):
 
 
 @export
-def buildSourceContainer(target, opts=None, priority=None, channel='container'):
+def buildSourceContainer(target, opts=None, priority=None, channel='container-source'):
     """Create a source container build task
 
     :param str target: The build target for this container.
@@ -97,8 +96,7 @@ def buildSourceContainer(target, opts=None, priority=None, channel='container'):
                          priority, relative to the default priority; higher
                          values mean lower priority; only admins have the
                          right to specify a negative priority here
-    :param str channel: the channel to allocate the task to (defaults to the
-                        "container" channel)
+    :param str channel: the channel to allocate the task to
     :returns: the task ID (integer)
     """
     new_opts, taskOpts = _get_task_opts_and_opts(opts, priority, channel)

--- a/tests/test_hub_containerbuild.py
+++ b/tests/test_hub_containerbuild.py
@@ -62,6 +62,8 @@ def mocked_kojihub_for_task(src, target, opts,
     :return: A mock object to replace hub_containerbuild.kojihub with.
     """
     task_opts = {}
+    if build_type == 'buildSourceContainer':
+        channel = 'container-source'
     if channel:
         task_opts['channel'] = channel
     if priority:


### PR DESCRIPTION
Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
