### PR TITLE
Do not try to get koji-build-id of scratch tasks

### DIFF
--- a/koji_containerbuild/plugins/builder_containerbuild.py
+++ b/koji_containerbuild/plugins/builder_containerbuild.py
@@ -588,7 +588,8 @@ class BaseContainerTask(BaseTaskHandler):
                          repositories)
 
         koji_build_id = None
-        if has_succeeded:
+        if has_succeeded and not self.opts.get('scratch'):
+            # Only successful, non-scratch tasks create Koji builds
             # For backward compatibility reasons, koji_build_id has to be a string
             koji_build_id = str(build_results['koji-build-id'])
 

--- a/tests/test_builder_containerbuild.py
+++ b/tests/test_builder_containerbuild.py
@@ -368,10 +368,17 @@ class TestBuilder(object):
         (flexmock(osbs.api.OSBS).should_receive('get_build_reason').and_return('Succeeded'))
         (flexmock(osbs.api.OSBS).should_receive('build_has_succeeded').and_return(True))
         (flexmock(osbs.api.OSBS).should_receive('build_was_cancelled').and_return(False))
-        repos = {"unique": ["unique-repo"], "primary": ["primary-repo"]}
+
+        build_results = {
+            'repositories': {'unique': ['unique-repo'], 'primary': ['primary-repo']}
+        }
+        if not create_build_args.get('scratch'):
+            # only non-scratch tasks create Koji builds
+            build_results['koji-build-id'] = koji_build_id
         (flexmock(osbs.api.OSBS)
             .should_receive('get_build_results')
-            .and_return({'repositories': repos, 'koji-build-id': koji_build_id}))
+            .and_return(build_results))
+
         (flexmock(osbs.api.OSBS).should_receive('build_not_finished').and_return(False))
         (flexmock(osbs.api.OSBS).should_receive('cancel_build').never())
         (flexmock(osbs.api.OSBS)
@@ -926,7 +933,7 @@ class TestBuilder(object):
 
         assert task_response == {
             'repositories': ['unique-repo', 'primary-repo'],
-            'koji_builds': [str(koji_build_id)]
+            'koji_builds': [str(koji_build_id)] if not additional_args.get('scratch') else []
         }
 
     @pytest.mark.parametrize('log_upload_raises', (True, False))
@@ -991,7 +998,7 @@ class TestBuilder(object):
 
         assert task_response == {
             'repositories': ['unique-repo', 'primary-repo'],
-            'koji_builds': [str(koji_build_id)]
+            'koji_builds': [str(koji_build_id)] if not additional_args.get('scratch') else []
         }
 
     @pytest.mark.parametrize(('isolated', 'release', 'koji_parent_build'), (
@@ -1374,7 +1381,7 @@ class TestBuilder(object):
 
             assert task_response == {
                 'repositories': ['unique-repo', 'primary-repo'],
-                'koji_builds': [str(koji_build_id)]
+                'koji_builds': [str(koji_build_id)] if not additional_args.get('scratch') else []
             }
 
     @pytest.mark.parametrize('arg_name, arg_value, expected_types', [


### PR DESCRIPTION
CLOUDBLD-8889

Scratch tasks do not create Koji builds => there is no koji-build-id in
the build_results.

Fix unit test mocking accordingly.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
