### PR TITLE
test.sh: add repo dir as safe directory

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -128,6 +128,9 @@ function setup_kojic() {
 
   # Pip install packages for unit tests
   $RUN "${PIP_INST[@]}" -r tests/requirements.txt
+
+  # workaround for https://github.com/actions/checkout/issues/766
+  $RUN git config --global --add safe.directory "$PWD"
 }
 
 case ${ACTION} in


### PR DESCRIPTION
See https://github.com/containerbuildsystem/atomic-reactor/pull/1896

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [n/a] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
