### PR TITLE
Remove pipeline after build finishes

### DIFF
--- a/koji_containerbuild/plugins/builder_containerbuild.py
+++ b/koji_containerbuild/plugins/builder_containerbuild.py
@@ -503,6 +503,12 @@ class BaseContainerTask(BaseTaskHandler):
                                logger=self.logger)
 
     def handle_build_response(self, build_id, platforms: list = None):
+        try:
+            return self._handle_build_response(build_id, platforms)
+        finally:
+            self.osbs().remove_build(build_id)
+
+    def _handle_build_response(self, build_id, platforms: list = None):
         self.logger.debug("OSBS build id: %r", build_id)
 
         # When builds are cancelled the builder plugin process gets SIGINT and SIGKILL

--- a/tests/test_builder_containerbuild.py
+++ b/tests/test_builder_containerbuild.py
@@ -304,6 +304,9 @@ class TestBuilder(object):
         create_build_args.setdefault('target', 'target-name')
         create_build_args.setdefault('scratch', False)
 
+        # validation exception => the build did not start
+        build_not_started = build_not_started or with_osbsvalidationexception
+
         if not source:
             create_build_args.setdefault('component', 'fedora-docker')
             create_build_args.setdefault('git_uri', src['git_uri'])
@@ -385,6 +388,10 @@ class TestBuilder(object):
             .should_receive('get_build_error_message')
             .and_return("build error"))
         (flexmock(osbs.api.OSBS).should_receive('wait_for_build_to_finish').and_return(None))
+        (flexmock(osbs.api.OSBS)
+            .should_receive('remove_build')
+            .times(0 if build_not_started else 1)
+            .and_return({'kind': 'Status', 'apiVersion': 'v1', 'status': 'Success'}))
 
     def _mock_folders(self, tmpdir, dockerfile_content=None, additional_tags_content=None):
         if dockerfile_content is None:


### PR DESCRIPTION
CLOUDBLD-10155

To prevent finished pipelines (successfully or not) from taking up
resources, delete them as soon as possible.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
