### PR TITLE
Honour allowed_scms_use_* kojid options

### DIFF
--- a/koji-containerbuild.spec
+++ b/koji-containerbuild.spec
@@ -52,7 +52,7 @@ Hub plugin that extend Koji to support building layered container images
 License:    LGPLv2
 Summary:    Builder plugin that extend Koji to build layered container images
 Group:      Applications/System
-Requires:   koji-builder
+Requires:   koji-builder >= 1.26
 Requires:   koji-containerbuild
 Requires:   osbs-client
 Requires:   python3-dockerfile-parse

--- a/koji_containerbuild/plugins/builder_containerbuild.py
+++ b/koji_containerbuild/plugins/builder_containerbuild.py
@@ -734,7 +734,19 @@ class BuildContainerTask(BaseContainerTask):
         self.logger.debug("Started by %s", owner_info['name'])
 
         scm = My_SCM(src)
-        scm.assert_allowed(self.options.allowed_scms)
+        scm_policy_opts = {
+            'user_id': this_task['owner'],
+            'channel': self.session.getChannel(this_task['channel_id'],
+                                               strict=True)['name'],
+            'scratch': bool(scratch),
+        }
+        scm.assert_allowed(
+                allowed=self.options.allowed_scms,
+                session=self.session,
+                by_config=self.options.allowed_scms_use_config,
+                by_policy=self.options.allowed_scms_use_policy,
+                policy_data=scm_policy_opts)
+
         git_uri = scm.get_git_uri()
         component = scm.get_component()
 
@@ -825,7 +837,6 @@ class BuildContainerTask(BaseContainerTask):
         Gets Dockerfile. Roughly corresponds to getSRPM method of build task
         """
         scm = SCM(src)
-        scm.assert_allowed(self.options.allowed_scms)
         scmdir = os.path.join(self.workdir, 'sources')
 
         koji.ensuredir(scmdir)

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,2 +1,2 @@
 git+https://github.com/projectatomic/osbs-client
-koji
+koji>=1.26

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 jsonschema==3.2.0
 six
+koji>=1.26

--- a/test.sh
+++ b/test.sh
@@ -31,14 +31,14 @@ function setup_kojic() {
     PIP_PKG="$PYTHON-pip"
     PIP="pip"
     PKG="yum"
-    PKG_EXTRA=(yum-utils git-core koji koji-hub)
+    PKG_EXTRA=(yum-utils git-core koji koji-hub python-gssapi)
     BUILDDEP="yum-builddep"
   else
     PYTHON="python$PYTHON_VERSION"
     PIP_PKG="$PYTHON-pip"
     PIP="pip$PYTHON_VERSION"
     PKG="dnf"
-    PKG_EXTRA=(dnf-plugins-core git-core "$PYTHON"-koji "$PYTHON"-koji-hub)
+    PKG_EXTRA=(dnf-plugins-core git-core "$PYTHON"-koji "$PYTHON"-koji-hub "$PYTHON"-gssapi)
     BUILDDEP=(dnf builddep)
   fi
 

--- a/tests/test_builder_containerbuild.py
+++ b/tests/test_builder_containerbuild.py
@@ -42,6 +42,14 @@ def mock_incremental_upload(session, fname, fd, uploadpath, logger=None):
     pass
 
 
+def mock_options_and_assert_allowed():
+    flexmock(koji.daemon.SCM).should_receive('assert_allowed').and_return(True)
+
+    return flexmock(allowed_scms='pkgs.example.com:/*:no',
+                    allowed_scms_use_config=True,
+                    allowed_scms_use_policy=True)
+
+
 class mock_time():
     def sleep(self, *args):
         return
@@ -284,11 +292,14 @@ class TestBuilder(object):
         (session
             .should_receive('getTaskInfo')
             .with_args(koji_task_id)
-            .and_return({'owner': 'owner'}))
+            .and_return({'owner': 'owner', 'channel_id': 1}))
         (session
             .should_receive('getUser')
             .with_args('owner')
             .and_return({'name': 'owner-name'}))
+        (session
+            .should_receive('getChannel')
+            .and_return({'name': 'default_channel'}))
         (session
             .should_receive('getPackageConfig')
             .with_args('dest-tag', 'fedora-docker')
@@ -537,7 +548,7 @@ class TestBuilder(object):
         session = self._mock_session(last_event_id, koji_task_id, pkg_info)
         folders_info = self._mock_folders(str(tmpdir))
         src = self._mock_git_source()
-        options = flexmock(allowed_scms='pkgs.example.com:/*:no')
+        options = mock_options_and_assert_allowed()
 
         task = builder_containerbuild.BuildContainerTask(id=koji_task_id,
                                                          method='buildContainer',
@@ -597,7 +608,7 @@ class TestBuilder(object):
             .should_receive('getPackageConfig')
             .with_args('dest-tag', 'source_package-source')
             .and_return(pkg_info))
-        options = flexmock(allowed_scms='pkgs.example.com:/*:no')
+        options = mock_options_and_assert_allowed()
 
         task = builder_containerbuild.BuildSourceContainerTask(id=koji_task_id,
                                                                method='buildSourceContainer',
@@ -646,7 +657,7 @@ class TestBuilder(object):
         session = self._mock_session(last_event_id, koji_task_id)
         folders_info = self._mock_folders(str(tmpdir))
         src = self._mock_git_source()
-        options = flexmock(allowed_scms='pkgs.example.com:/*:no')
+        options = mock_options_and_assert_allowed()
 
         task = builder_containerbuild.BuildContainerTask(id=koji_task_id,
                                                          method='buildContainer',
@@ -710,7 +721,7 @@ class TestBuilder(object):
             .should_receive('getPackageConfig')
             .with_args('dest-tag', 'source_package-source')
             .and_return({'blocked': False}))
-        options = flexmock(allowed_scms='pkgs.example.com:/*:no')
+        options = mock_options_and_assert_allowed()
 
         task = builder_containerbuild.BuildSourceContainerTask(id=koji_task_id,
                                                                method='buildSourceContainer',
@@ -826,7 +837,7 @@ class TestBuilder(object):
         koji_task_id = 123
         last_event_id = 456
 
-        options = flexmock(allowed_scms='pkgs.example.com:/*:no')
+        options = mock_options_and_assert_allowed()
         folders_info = self._mock_folders(str(tmpdir))
 
         pkg_info = {'blocked': False}
@@ -896,7 +907,7 @@ class TestBuilder(object):
         session = self._mock_session(last_event_id, koji_task_id)
         folders_info = self._mock_folders(str(tmpdir))
         src = self._mock_git_source()
-        options = flexmock(allowed_scms='pkgs.example.com:/*:no')
+        options = mock_options_and_assert_allowed()
 
         task = builder_containerbuild.BuildContainerTask(id=koji_task_id,
                                                          method='buildContainer',
@@ -961,7 +972,7 @@ class TestBuilder(object):
             .with_args('dest-tag', 'source_package-source')
             .and_return({'blocked': False}))
 
-        options = flexmock(allowed_scms='pkgs.example.com:/*:no')
+        options = mock_options_and_assert_allowed()
 
         task = builder_containerbuild.BuildSourceContainerTask(id=koji_task_id,
                                                                method='buildSourceContainer',
@@ -1015,7 +1026,7 @@ class TestBuilder(object):
         session = self._mock_session(last_event_id, task_id, {'blocked': False})
         folders_info = self._mock_folders(str(tmpdir))
         src = self._mock_git_source()
-        options = flexmock(allowed_scms='pkgs.example.com:/*:no')
+        options = mock_options_and_assert_allowed()
 
         task = builder_containerbuild.BuildContainerTask(id=task_id,
                                                          method='buildContainer',
@@ -1070,7 +1081,7 @@ class TestBuilder(object):
         session = self._mock_session(last_event_id, koji_task_id)
         folders_info = self._mock_folders(str(tmpdir), additional_tags_content=tag)
         src = self._mock_git_source()
-        options = flexmock(allowed_scms='pkgs.example.com:/*:no')
+        options = mock_options_and_assert_allowed()
 
         task = builder_containerbuild.BuildContainerTask(id=koji_task_id,
                                                          method='buildContainer',
@@ -1145,7 +1156,7 @@ class TestBuilder(object):
 
         folders_info = self._mock_folders(str(tmpdir), dockerfile_content=dockerfile_content)
         src = self._mock_git_source()
-        options = flexmock(allowed_scms='pkgs.example.com:/*:no')
+        options = mock_options_and_assert_allowed()
 
         task = builder_containerbuild.BuildContainerTask(id=koji_task_id,
                                                          method='buildContainer',
@@ -1245,7 +1256,7 @@ class TestBuilder(object):
             log_message = ('koji build {} is source container build, source container can not '
                            'use source container build image'.format(provided_nvr))
 
-        options = flexmock(allowed_scms='pkgs.example.com:/*:no')
+        options = mock_options_and_assert_allowed()
 
         task = builder_containerbuild.BuildSourceContainerTask(id=koji_task_id,
                                                                method='buildSourceContainer',
@@ -1284,7 +1295,7 @@ class TestBuilder(object):
         session = self._mock_session(last_event_id, koji_task_id)
         folders_info = self._mock_folders(str(tmpdir))
         src = self._mock_git_source()
-        options = flexmock(allowed_scms='pkgs.example.com:/*:no')
+        options = mock_options_and_assert_allowed()
 
         task = builder_containerbuild.BuildContainerTask(id=koji_task_id,
                                                          method='buildContainer',
@@ -1347,7 +1358,7 @@ class TestBuilder(object):
         session = self._mock_session(last_event_id, koji_task_id)
         folders_info = self._mock_folders(str(tmpdir))
         src = self._mock_git_source()
-        options = flexmock(allowed_scms='pkgs.example.com:/*:no')
+        options = mock_options_and_assert_allowed()
 
         task = builder_containerbuild.BuildContainerTask(id=koji_task_id,
                                                          method='buildContainer',
@@ -1682,7 +1693,7 @@ class TestBuilder(object):
 
         session = self._mock_session(last_event_id, koji_task_id)
         src = self._mock_git_source()
-        options = flexmock(allowed_scms='pkgs.example.com:/*:no')
+        options = mock_options_and_assert_allowed()
 
         builder_containerbuild.incremental_upload = mock_incremental_upload
 
@@ -1727,7 +1738,7 @@ class TestBuilder(object):
         session = self._mock_session(last_event_id, koji_task_id)
         folders_info = self._mock_folders(str(tmpdir))
         src = self._mock_git_source()
-        options = flexmock(allowed_scms='pkgs.example.com:/*:no')
+        options = mock_options_and_assert_allowed()
 
         builder_containerbuild.incremental_upload = mock_incremental_upload
 
@@ -1784,7 +1795,7 @@ class TestBuilder(object):
             .should_receive('getPackageConfig')
             .with_args('dest-tag', 'source_package-source')
             .and_return({'blocked': False}))
-        options = flexmock(allowed_scms='pkgs.example.com:/*:no')
+        options = mock_options_and_assert_allowed()
 
         task = builder_containerbuild.BuildSourceContainerTask(id=koji_task_id,
                                                                method='buildSourceContainer',


### PR DESCRIPTION
* CLOUDBLD-10221

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
