### PR TITLE
Honour allowed_scms_use_* kojid options

### DIFF
--- a/koji-containerbuild.spec
+++ b/koji-containerbuild.spec
@@ -52,7 +52,7 @@ Hub plugin that extend Koji to support building layered container images
 License:    LGPLv2
 Summary:    Builder plugin that extend Koji to build layered container images
 Group:      Applications/System
-Requires:   koji-builder
+Requires:   koji-builder >= 1.26
 Requires:   koji-containerbuild
 Requires:   osbs-client
 %if 0%{with python3}

--- a/koji_containerbuild/plugins/builder_containerbuild.py
+++ b/koji_containerbuild/plugins/builder_containerbuild.py
@@ -761,7 +761,19 @@ class BuildContainerTask(BaseContainerTask):
         self.logger.debug("Started by %s", owner_info['name'])
 
         scm = My_SCM(src)
-        scm.assert_allowed(self.options.allowed_scms)
+        scm_policy_opts = {
+            'user_id': this_task['owner'],
+            'channel': self.session.getChannel(this_task['channel_id'],
+                                               strict=True)['name'],
+            'scratch': bool(scratch),
+        }
+        scm.assert_allowed(
+                allowed=self.options.allowed_scms,
+                session=self.session,
+                by_config=self.options.allowed_scms_use_config,
+                by_policy=self.options.allowed_scms_use_policy,
+                policy_data=scm_policy_opts)
+
         git_uri = scm.get_git_uri()
         component = scm.get_component()
         arch = None
@@ -878,7 +890,6 @@ class BuildContainerTask(BaseContainerTask):
         Gets Dockerfile. Roughly corresponds to getSRPM method of build task
         """
         scm = SCM(src)
-        scm.assert_allowed(self.options.allowed_scms)
         scmdir = os.path.join(self.workdir, 'sources')
 
         koji.ensuredir(scmdir)

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,2 +1,2 @@
 git+https://github.com/projectatomic/osbs-client
-koji
+koji>=1.26

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 jsonschema==3.2.0
 six
+koji>=1.26

--- a/test.sh
+++ b/test.sh
@@ -31,14 +31,14 @@ function setup_kojic() {
     PIP_PKG="$PYTHON-pip"
     PIP="pip"
     PKG="yum"
-    PKG_EXTRA=(yum-utils git-core koji koji-hub)
+    PKG_EXTRA=(yum-utils git-core koji koji-hub python-gssapi)
     BUILDDEP="yum-builddep"
   else
     PYTHON="python$PYTHON_VERSION"
     PIP_PKG="$PYTHON-pip"
     PIP="pip$PYTHON_VERSION"
     PKG="dnf"
-    PKG_EXTRA=(dnf-plugins-core git-core "$PYTHON"-koji "$PYTHON"-koji-hub)
+    PKG_EXTRA=(dnf-plugins-core git-core "$PYTHON"-koji "$PYTHON"-koji-hub "$PYTHON"-gssapi)
     BUILDDEP=(dnf builddep)
   fi
 
@@ -136,6 +136,10 @@ case ${ACTION} in
   setup_kojic
   # This can run only at fedora because pylint is not packaged in centos
   # use distro pylint to not get too new pylint version
+  if [[ ${PYTHON_VERSION} == "2" ]]; then
+    $RUN $PKG remove -y python2-koji
+  fi
+
   $RUN $PKG install -y "${PYTHON}-pylint"
   PACKAGES='koji_containerbuild tests'
   TEST_CMD="${PYTHON} -m pylint ${PACKAGES}"


### PR DESCRIPTION
Introduced in koji 1.26 (https://pagure.io/koji/issue/2757)

* CLOUDBLD-10221

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
