### PR TITLE
Revert "Pin jsonschema==3.2.0 in requirements.txt"

### DIFF
--- a/requirements-py2.txt
+++ b/requirements-py2.txt
@@ -1,0 +1,3 @@
+jsonschema==3.2.0
+six
+koji>=1.26

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-jsonschema==3.2.0
+jsonschema
 six
 koji>=1.26

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ class TitoDist(sdist):
         subprocess.call(["tito", "build", "--tgz", "-o", "."])
 
 
-def get_requirements(requirements_file='requirements.txt'):
+def _get_requirements(requirements_file='requirements.txt'):
     with open(requirements_file) as f:
         return [
             line.split('#')[0].rstrip()
@@ -18,6 +18,12 @@ def get_requirements(requirements_file='requirements.txt'):
             if not line.startswith('#')
             ]
 
+def _install_requirements():
+    if sys.version_info[0] >= 3:
+        requirements = _get_requirements('requirements.txt')
+    else:
+        requirements = _get_requirements('requirements-py2.txt')
+    return requirements
 
 class Py2CLIOnlyBuild(build_py):
 
@@ -46,7 +52,7 @@ setup(
         'koji_containerbuild',
         'koji_containerbuild.plugins',
     ],
-    install_requires=get_requirements(),
+    install_requires=_install_requirements(),
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Topic :: Internet",


### PR DESCRIPTION
We don't need specific version anymore, py2 support has been dropped.

This reverts commit eb1aac6fa045daf9e0fa0449b6aaa4172293e450

Fixes: #242

Signed-off-by: Martin Basti <mbasti@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
