### PR TITLE
Bring back skip_build option

### DIFF
--- a/koji_containerbuild/plugins/builder_containerbuild.py
+++ b/koji_containerbuild/plugins/builder_containerbuild.py
@@ -704,6 +704,12 @@ class BuildContainerTask(BaseContainerTask):
                         "possible names, see REACTOR_CONFIG in "
                         "orchestrator.log."
                     },
+                    "skip_build": {
+                        "type": "boolean",
+                        "description": "[DEPRECATED] "
+                        "Skip build, just update buildconfig for autorebuild "
+                        "and don't start build"
+                    },
                     "userdata": {
                         "type": "object",
                         "description": "User defined dictionary containing custom metadata",
@@ -746,10 +752,17 @@ class BuildContainerTask(BaseContainerTask):
                         scratch=None, isolated=None, yum_repourls=None,
                         branch=None, koji_parent_build=None, release=None,
                         flatpak=False, signing_intent=None, compose_ids=None,
+                        skip_build=None,  # BW compatibility
                         dependency_replacements=None, operator_csv_modifications_url=None,
                         userdata=None):
         if not yum_repourls:
             yum_repourls = []
+
+        if skip_build is not None:
+            if skip_build:
+                raise koji.BuildError("'skip_build' functionality has been removed")
+            else:
+                self.logger.warning("deprecated option 'skip_build' in build params")
 
         this_task = self.session.getTaskInfo(self.id)
         self.logger.debug("This task: %r", this_task)
@@ -986,6 +999,7 @@ class BuildContainerTask(BaseContainerTask):
             signing_intent=opts.get('signing_intent', None),
             compose_ids=opts.get('compose_ids', None),
             operator_csv_modifications_url=opts.get('operator_csv_modifications_url'),
+            skip_build=opts.get('skip_build', None),
             userdata=opts.get('userdata', None),
         )
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
+attrs==21.4.*;python_version<"3"  # pytest-dep, pin to py2 supported version
 flexmock==0.10.4
 pytest>=4.1.0
 pytest-cov


### PR DESCRIPTION
This option must be kept for BW compatibility, tools like rpkg are
adding skip_build=False to task options.

However when skip_build is True, build must fail becasue this feature
has been dropped

CLOUDBLD-10709

Signed-off-by: Martin Basti <mbasti@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
