### PR TITLE
add logs in osbs build log to indicate platform specific

### DIFF
--- a/koji_containerbuild/plugins/builder_containerbuild.py
+++ b/koji_containerbuild/plugins/builder_containerbuild.py
@@ -435,6 +435,10 @@ class BaseContainerTask(BaseTaskHandler):
                 if (task_platform != 'noarch') and (task_platform not in final_platforms):
                     continue
 
+                if task_platform != 'noarch':
+                    logfiles['noarch'].write(bytearray(f'{task_platform} build has started. '
+                                                       'Check platform specific logs\n', 'utf-8'))
+
                 log_filename = f'{task_platform}.log'
                 logfiles[task_platform] = open(os.path.join(logs_dir, log_filename),
                                                'wb')

--- a/tests/test_builder_containerbuild.py
+++ b/tests/test_builder_containerbuild.py
@@ -133,6 +133,11 @@ class TestBuilder(object):
             else:
                 if task_platform != 'noarch':
                     log_filename = f'{task_platform}'
+                    if log_filename not in log_contents:
+                        log_contents[log_name] = '{old}{new}\n'.format(
+                            old=log_contents.get(log_name, ''),
+                            new=f'{task_platform} build has started. '
+                                'Check platform specific logs')
                 else:
                     log_filename = log_name
                 log_contents[log_filename] = '{old}{new}\n'.format(
@@ -203,7 +208,12 @@ class TestBuilder(object):
 
         koji_tmpdir = tmpdir.mkdir('koji')
         koji_tmpdir.join('x.log').write('line 1\n'
-                                        'line 2\n')
+                                        'line 2\n'
+                                        'x86_64 build has started. Check platform specific logs\n'
+                                        's390x build has started. Check platform specific logs\n'
+                                        'ppc64le build has started. Check platform specific logs\n'
+                                        'aarch64 build has started. Check platform specific logs\n'
+                                        )
 
         (flexmock(koji.pathinfo)
             .should_receive('work')


### PR DESCRIPTION
build has started

* CLOUDBLD-10692

Signed-off-by: Harsh Modi <hmodi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
