### PR TITLE
Don't fail build when removing build fails, pipeline run could be alr…

### DIFF
--- a/koji_containerbuild/plugins/builder_containerbuild.py
+++ b/koji_containerbuild/plugins/builder_containerbuild.py
@@ -522,7 +522,10 @@ class BaseContainerTask(BaseTaskHandler):
         try:
             return self._handle_build_response(build_id, platforms)
         finally:
-            self.osbs().remove_build(build_id)
+            try:
+                self.osbs().remove_build(build_id)
+            except Exception as error:
+                self.logger.warning("Failed to remove build %s : %s", build_id, error)
 
     def _handle_build_response(self, build_id, platforms: list = None):
         self.logger.debug("OSBS build id: %r", build_id)


### PR DESCRIPTION
…eady

removed, and build shouldn't fail just because it couldn't delete pipeline run

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
