### PR TITLE
Bump osbs-client dependency

### DIFF
--- a/koji-containerbuild.spec
+++ b/koji-containerbuild.spec
@@ -54,7 +54,7 @@ Summary:    Builder plugin that extend Koji to build layered container images
 Group:      Applications/System
 Requires:   koji-builder >= 1.26
 Requires:   koji-containerbuild
-Requires:   osbs-client
+Requires:   osbs-client >= 2.0.0
 Requires:   python3-dockerfile-parse
 Requires:   python3-jsonschema
 Requires:   python3-six


### PR DESCRIPTION
New version of koji-c-plugin for OSBS2 needs osbs-client>=2.0.0

Signed-off-by: Martin Basti <mbasti@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [n/a] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
