### PR TITLE
pass default and max build times from osbs.conf via kwargs to

### DIFF
--- a/koji_containerbuild/plugins/builder_containerbuild.py
+++ b/koji_containerbuild/plugins/builder_containerbuild.py
@@ -830,6 +830,11 @@ class BuildContainerTask(BaseContainerTask):
         if release:
             create_build_args['release'] = release
 
+        create_build_args['default_buildtime_limit'] =\
+            self.osbs().os_conf.get_default_buildtime_limit()
+        create_build_args['max_buildtime_limit'] =\
+            self.osbs().os_conf.get_max_buildtime_limit()
+
         try:
             create_method = self.osbs().create_binary_container_build
             self.logger.debug("Starting %s with params: '%s",

--- a/tests/test_builder_containerbuild.py
+++ b/tests/test_builder_containerbuild.py
@@ -384,6 +384,10 @@ class TestBuilder(object):
         if not create_build_args.get('userdata'):
             create_build_args.pop('userdata', None)
 
+        if not source:
+            create_build_args['default_buildtime_limit'] = 10800
+            create_build_args['max_buildtime_limit'] = 21600
+
         if source:
             (flexmock(osbs.api.OSBS)
                 .should_receive('create_source_container_build')


### PR DESCRIPTION
create_binary_container_build

* CLOUDBLD-9913

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
