### PR TITLE
builder: document compose_ids behavior

### DIFF
--- a/koji_containerbuild/plugins/builder_containerbuild.py
+++ b/koji_containerbuild/plugins/builder_containerbuild.py
@@ -710,7 +710,13 @@ class BuildContainerTask(BaseContainerTask):
                         "items": {
                             "type": "integer"
                         },
-                        "description": "ODCS composes used."
+                        "description": "A list of ODCS composes to use "
+                        "during the build. If you do not set this parameter, "
+                        "OSBS will request its own ODCS composes based on "
+                        "the compose settings in container.yaml. If you set "
+                        "this parameter, OSBS will not request its own ODCS "
+                        "composes, and it will only use the exact ones you "
+                        "specify here."
                     },
                     "signing_intent": {
                         "type": ["string", "null"],


### PR DESCRIPTION
Update the JSON schema for `compose_ids` to explain that when a user specifies `compose_ids`, OSBS will not generate new composes.